### PR TITLE
fix node size bug on some monitors

### DIFF
--- a/src/main/webapp/js/shark_viewer.js
+++ b/src/main/webapp/js/shark_viewer.js
@@ -393,7 +393,7 @@ SharkViewer.prototype.init = function () {
 		// properties that may vary from particle to particle. only accessible in vertex shaders!
 		//	(can pass color info to fragment shader via vColor.)
 		// compute scale for particles, in pixels
-		var particleScale =  0.5 * this.HEIGHT / Math.tan(0.5 * fov * Math.PI / 180.0);
+		var particleScale =  (0.5 * this.HEIGHT * this.renderer.devicePixelRatio) / Math.tan(0.5 * fov * Math.PI / 180.0);
 	
 		var customAttributes = 
 		{


### PR DESCRIPTION
There was a bug with some monitors where the nodes from the swc would be rendered too small if the devicePixelRatio > 1.
